### PR TITLE
Simplified the technique for checking the existence of a config file in the repo

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,13 +94,13 @@ def main():
             # Configuration file
             PEP8SPEAK_YML_FOUND = False
             r = requests.get("https://api.github.com/repos/" + repository +
-                             "/contents/").json()
-            for content in r:
-                if content["name"] == ".pep8speaks.yml":
-                    PEP8SPEAK_YML_FOUND = True
-                    res = requests.get(content["download_url"])
-                    with open(".pep8speaks.yml", "w+") as config_file:
-                        config_file.write(res.text)
+                             "/contents/.pep8speaks.yml")
+            if r.status_code == 200:
+                PEP8SPEAK_YML_FOUND = True
+                res = requests.get(r.json()["download_url"])
+                with open(".pep8speaks.yml", "w+") as config_file:
+                    config_file.write(res.text)
+            # Handle the case of no configuration file resulting in a 404 response code
 
             # Update default config with those provided
             try:


### PR DESCRIPTION
This PR simplifies the way we check for the existence of a `.pep8speaks.yml` - the configuration file in the repository.
Rather than looping through all the `contents` and equating their `name` with `.pep8speaks.yml`, we can directly make an API call to the configuration file. Not only will this improve the time complexity(not that it matters here) but also clarify the code block.