### PR TITLE
Improvement/subprocess

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 from bs4 import BeautifulSoup
@@ -216,11 +217,11 @@ def run_pycodestyle(data, config):
             file_to_check.write(r.text)
 
         # Use the command line here
-        cmd = "pycodestyle {} file_to_check.py > pycodestyle_result.txt"
-        os.system(cmd.format(config["pycodestyle_cmd_config"]))
-
-        with open("pycodestyle_result.txt", "r") as f:
-            data["extra_results"][filename] = f.readlines()
+        cmd = 'pycodestyle {config[pycodestyle_cmd_config]} file_to_check.py'.format(
+            config=config)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        stdout, _ = proc.communicate()
+        data["extra_results"][filename] = stdout.splitlines()
 
         # Put only relevant errors in the data["results"] dictionary
         data["results"][filename] = []
@@ -242,7 +243,6 @@ def run_pycodestyle(data, config):
         data[filename + "_link"] = url
 
         os.remove("file_to_check.py")
-        os.remove("pycodestyle_result.txt")
 
 
 def prepare_comment(request, data, config):

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -429,10 +429,11 @@ def autopep8(data, config):
         with open("file_to_fix.py", 'w+') as file_to_fix:
             file_to_fix.write(r.text)
 
-        # Store the diff in .diff file
-        os.system("autopep8 file_to_fix.py --diff {} > autopep8.diff".format(arg_to_ignore))
-        with open("autopep8.diff", "r") as f:
-            data["diff"][filename] = f.read()
+        cmd = 'autopep8 file_to_fix.py --diff {arg_to_ignore}'.format(
+            arg_to_ignore=arg_to_ignore)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        stdout, _ = proc.communicate()
+        data["diff"][filename] = stdout.decode('utf-8')
 
         # Fix the errors
         data["diff"][filename] = data["diff"][filename].replace("file_to_check.py", filename)
@@ -445,7 +446,6 @@ def autopep8(data, config):
         data[filename + "_link"] = url
 
         os.remove("file_to_fix.py")
-        os.remove("autopep8.diff")
 
 
 def create_gist(data, config):

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -221,7 +221,7 @@ def run_pycodestyle(data, config):
             config=config)
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         stdout, _ = proc.communicate()
-        data["extra_results"][filename] = stdout.splitlines()
+        data["extra_results"][filename] = stdout.decode('utf-8').splitlines()
 
         # Put only relevant errors in the data["results"] dictionary
         data["results"][filename] = []

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -590,10 +590,11 @@ def autopep8ify(data, config):
         with open("file_to_fix.py", 'w+') as file_to_fix:
             file_to_fix.write(r.text)
 
-        # Store the diff in .diff file
-        os.system("autopep8 file_to_fix.py --in-place {}".format(arg_to_ignore))
-        with open("file_to_fix.py", "r") as f:
-            data["results"][filename] = f.read()
+        cmd = 'autopep8 file_to_fix.py {arg_to_ignore}'.format(
+            arg_to_ignore=arg_to_ignore)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        stdout, _ = proc.communicate()
+        data["results"][filename] = stdout.decode('utf-8')
 
         os.remove("file_to_fix.py")
 


### PR DESCRIPTION
This PR replaces `os.system` calls with equivalent `subprocess` calls.

Because even `os.system`'s [docs say](https://docs.python.org/2/library/os.html#os.system):

> The `subprocess` module provides more powerful facilities for spawning new processes and retrieving their results; using that module is preferable to using this function.