### PR TITLE
Do not mention files with no errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ pycodestyle:
         - E203
 
 no_blank_comment: False  # If True, no comment is made when the bot does not find any pep8 errors
+
+only_mention_files_with_errors: True  # If set to False, a separate status comment for each file is made.
 ```
+
+Check out the [default configuration options](https://github.com/OrkoHunter/pep8speaks/blob/master/pep8speaks/helpers.py#L87-L115).
 
 Note : See more [pycodestyle options](https://pycodestyle.readthedocs.io/en/latest/intro.html#example-usage-and-output)
 

--- a/pep8speaks/handlers.py
+++ b/pep8speaks/handlers.py
@@ -77,6 +77,7 @@ def handle_pull_request(request):
         # Make the comment
         if PERMITTED_TO_COMMENT:
             helpers.create_or_update_comment(data, comment)
+
     js = json.dumps(data)
     return Response(js, status=200, mimetype='application/json')
 


### PR DESCRIPTION
Thanks to @glemaitre for the suggestion. **The default behavior from now is not to comment only about files with any errors**. If the reviewers explicitly wants to see the files checked by the bot, they need to add
```
"only_mention_files_with_errors": False
```
in the `.pep8speaks.yml` file.

Closes #25 