### PR TITLE
Fix for reading .pep8speaks.yml file

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -117,9 +117,9 @@ def get_config(data):
     auth = (os.environ["BOT_USERNAME"], os.environ["BOT_PASSWORD"])
 
     # Configuration file
-    url = "https://raw.githubusercontent.com/{}/{}/{}/.pep8speaks.yml"
-    repo = data["repository"].split("/")[-1]
-    url = url.format(data["author"], repo, data["after_commit_hash"])
+    url = "https://raw.githubusercontent.com/{}/{}/.pep8speaks.yml"
+
+    url = url.format(data["repository"], data["after_commit_hash"])
     r = requests.get(url, headers=headers, auth=auth)
     if r.status_code == 200:
         try:


### PR DESCRIPTION
According to issue #33 
[here](https://github.com/OrkoHunter/pep8speaks/blob/master/pep8speaks/helpers.py#L187) you make the same - maybe this is the reason why app check files but can't get yaml file.