### PR TITLE
Add [skip pep8] option to prevent bot from commenting on a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A GitHub :octocat: integration to automatically review Python code style over Pu
 # Features
 
  - The bot makes **a single comment on the PR and keeps updating it** on new commits. No hustle on emails !
+ - Add `[skip pep8]` anywhere in the commit message, PR title or PR description to prohibit pep8speaks to comment on the Pull Request.
  - To pause the bot on a PR, comment `@pep8speaks Keep Quiet.`
  - Comment `@pep8speaks Resume now.` to resume.
   - The keywords are `quiet` and `resume` and the mention of the bot.

--- a/pep8speaks/handlers.py
+++ b/pep8speaks/handlers.py
@@ -128,6 +128,9 @@ def handle_review(request):
         conditions_matched = condition1 and condition2
         if conditions_matched:
             return _create_diff(request, data, config)
+        else:
+            js = json.dumps(data)
+            return Response(js, status=200, mimetype='application/json')
 
 
 def _pep8ify(request, data, config):
@@ -282,6 +285,7 @@ def handle_issue_comment(request):
             js = json.dumps(data)
             return Response(js, status=200, mimetype='application/json')
     elif request.json["action"] == "deleted":
+        js = json.dumps(data)
         return Response(js, status=200, mimetype='application/json')
 
 

--- a/pep8speaks/handlers.py
+++ b/pep8speaks/handlers.py
@@ -29,6 +29,9 @@ def handle_pull_request(request):
             # pycodestyle arguments
             "extra_results": {},
             "pr_number": request.json["number"],
+            "commits_url": request.json["pull_request"]["commits_url"],
+            "pr_title": request.json["pull_request"]["title"],
+            "pr_desc": request.json["pull_request"]["body"]
         }
 
         # If the PR contains at least one Python file

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -361,6 +361,19 @@ def comment_permission_check(data, comment):
             elif 'quiet' in old_comment['body'].lower():
                 PERMITTED_TO_COMMENT = False
 
+    # Check for [skip pep8]
+    ## In commits
+    commits = requests.get(data["commits_url"], auth=auth).json()
+    for commit in commits:
+        if any(m in commit["commit"]["message"].lower() for m in ["[skip pep8]", "[pep8 skip]"]):
+            PERMITTED_TO_COMMENT = False
+            break
+    ## PR title
+    if any(m in data["pr_title"].lower() for m in ["[skip pep8]", "[pep8 skip]"]):
+        PERMITTED_TO_COMMENT = False
+    ## PR description
+    if any(m in data["pr_desc"].lower() for m in ["[skip pep8]", "[pep8 skip]"]):
+        PERMITTED_TO_COMMENT = False
 
     return PERMITTED_TO_COMMENT
 


### PR DESCRIPTION
In spirit of `[skip ci]` option used to prevent Travis running a build in a commit.

If a Pull Request has `[skip pep8]` (or `[pep8 skip]`) anywhere in the commit message, PR title or description, the bot will simply ignore the PR.