### PR TITLE
Fix pycodestyle exclude option

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -3,6 +3,7 @@
 import base64
 import collections
 import datetime
+import fnmatch
 import hmac
 import json
 import os
@@ -194,13 +195,20 @@ def get_files_involved_in_pr(data):
     return files
 
 
-def get_python_files_involved_in_pr(data):
+def get_python_files_involved_in_pr(data, exclude=[]):
     files = get_files_involved_in_pr(data)
     for file in list(files.keys()):
-        if file[-3:] != ".py":
+        if file[-3:] != ".py" or filename_match(file, exclude):
             del files[file]
 
     return files
+
+
+def filename_match(filename, patterns):
+    """
+    Check if patterns contains a pattern that matches filename.
+    """
+    return any(fnmatch(filename, pattern) for pattern in patterns)
 
 
 def run_pycodestyle(data, config):
@@ -217,7 +225,7 @@ def run_pycodestyle(data, config):
     # Run pycodestyle
     ## All the python files with additions
     # A dictionary with filename paired with list of new line numbers
-    py_files = get_python_files_involved_in_pr(data)
+    py_files = get_python_files_involved_in_pr(data, config["pycodestyle"]["exclude"])
 
     for file in py_files:
         filename = file[1:]


### PR DESCRIPTION
This fixes issue https://github.com/OrkoHunter/pep8speaks/issues/52.

It looks like the problem is that [pep8speaks is just running pycodestyle on a file called `file_to_check.py`](https://github.com/OrkoHunter/pep8speaks/blob/1c4e91530e23ba86b4bf2c3f84981548e7684b2a/pep8speaks/helpers.py#L231) so the `exclude` option never matches anything. We need to filter the files before this point. 

I tweaked [the filename_match function from pycodestyle](https://git.io/vQ7AR).

**NOTE**: I have not tested this code.