### PR TITLE
Drop PR review webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ A GitHub :octocat: integration to automatically review Python code style over Pu
 # Features
 
  - The bot makes **a single comment on the PR and keeps updating it** on new commits. No hustle on emails !
+ - The bot comments only if Python files are involved. So, install the integration on all of your repositories. The bot won't speak where it should not
+ - Comment `@pep8speaks suggest diff` in a comment of the PR, and it will comment a gist of diff suggesting fixes for the PR. [Example](https://github.com/OrkoHunter/test-pep8speaks/pull/22#issuecomment-270826241)
+  - You can also comment `@pep8speaks suggest the diff` or anything you wish, as long as you mention the bot and have `suggest` and `diff` keywords.
+ - Comment `@pep8speaks pep8ify` on the PR and it will create a Pull Request with changes suggested by [`autopep8`](https://github.com/hhatto/autopep8) against the branch of the author of the PR. `autopep8` fixes most of the errors reported by [`pycodestyle`](https://github.com/PyCQA/pycodestyle).
  - Add `[skip pep8]` anywhere in the commit message, PR title or PR description to prohibit pep8speaks to comment on the Pull Request.
  - To pause the bot on a PR, comment `@pep8speaks Keep Quiet.`
  - Comment `@pep8speaks Resume now.` to resume.
   - The keywords are `quiet` and `resume` and the mention of the bot.
- - Mention `@pep8speaks` in a **review summary** while creating a review of a PR, and it will comment a gist of diff suggesting fixes for the PR. [Example](https://github.com/OrkoHunter/test-pep8speaks/pull/22#issuecomment-270826241)
-  - In the review summary, you can also write `@pep8speaks suggest diff` or anything you wish, as long as you mention the bot and have `suggest` and `diff` keywords.
- - Write `@pep8speaks pep8ify` in a review summary and it will create a Pull Request with changes suggested by [`autopep8`](https://github.com/hhatto/autopep8) against the branch of the author of the PR. `autopep8` fixes most of the errors reported by [`pycodestyle`](https://github.com/PyCQA/pycodestyle).
-  - `@pep8speaks` along with `pep8ify` in a single review summary rules out the diff feature.
- - Comment only if Python files are involved. So, install the integration on all of your repositories. The bot won't speak where it should not
+
 
 # Configuration
 A config file is *not required* for the integration to work. However it can be configured additionally by adding a `.pep8speaks.yml` file to the base directory of the repo. Here are the available options of the config file :

--- a/app.py
+++ b/app.py
@@ -43,8 +43,6 @@ def create_app():
                 event = request.headers["X-GitHub-Event"]
                 event_to_action = {
                     "pull_request": handlers.handle_pull_request,
-                    "pull_request_review": handlers.handle_review,
-                    "pull_request_review_comment": handlers.handle_review_comment,
                     "integration_installation": handlers.handle_integration_installation,
                     "integration_installation_repositories": handlers.handle_integration_installation_repo,
                     "installation_repositories": handlers.handle_integration_installation_repo,

--- a/pep8speaks/handlers.py
+++ b/pep8speaks/handlers.py
@@ -69,46 +69,37 @@ def handle_pull_request(request):
     return utils.Response(ghrequest)
 
 
-def handle_installation(request):
-    """
-    Do nothing. It's handled by handle_integration_installation
-    """
-    return utils.Response()
-
-
-def handle_review(request):
-    """
-    Handle the request when a new review is submitted
-    """
-
+def handle_issue_comment(request):
     ghrequest = models.GHRequest(request, request.headers["X-GitHub-Event"])
 
-    if not ghrequest.review_body:
+    if not ghrequest.OK:
         return utils.Response(ghrequest)
 
     # Get the .pep8speaks.yml config file from the repository
     config = helpers.get_config(ghrequest.repository, ghrequest.base_branch)
 
-    condition1 = ghrequest.action == "submitted"
-    # Mainly the summary of the review matters
-    ## pep8speaks must be mentioned
-    condition2 = "@pep8speaks" in ghrequest.review_body
-    ## Check if asked to pep8ify
-    condition3 = "pep8ify" in ghrequest.review_body
+    splitted_comment = ghrequest.comment.lower().split()
 
-    ## If pep8ify is not there, all other reviews with body summary
-    ## having the mention of pep8speaks, will result in commenting
-    ## with autpep8 diff gist.
-    conditions_matched = condition1 and condition2 and condition3
+    # If diff is required
+    params1 = ["@pep8speaks", "suggest", "diff"]
+    condition1 = all(p in splitted_comment for p in params1)
+    # If asked to pep8ify
+    params2 = ["@pep8speaks", "pep8ify"]
+    condition2 = all(p in splitted_comment for p in params2)
 
-    if conditions_matched:
+    if condition1:
+        return _create_diff(ghrequest, config)
+    elif condition2:
         return _pep8ify(ghrequest, config)
-    else:
-        conditions_matched = condition1 and condition2
-        if conditions_matched:
-            return _create_diff(ghrequest, config)
-        else:
-            return utils.Response(ghrequest)
+
+    return utils.Response(ghrequest)
+
+
+def handle_installation(request):
+    """
+    Do nothing. It's handled by handle_integration_installation
+    """
+    return utils.Response()
 
 
 def _pep8ify(ghrequest, config):
@@ -183,11 +174,6 @@ def _create_diff(ghrequest, config):
     return utils.Response(ghrequest)
 
 
-def handle_review_comment(request):
-    # Figure out what does "position" mean in the response
-    return utils.Response()
-
-
 def handle_integration_installation(request):
     """
     Follow the user from the account of @pep8speaks on GitHub
@@ -220,32 +206,6 @@ def handle_ping(request):
     Do nothing
     """
     return utils.Response()
-
-
-def handle_issue_comment(request):
-    ghrequest = models.GHRequest(request, request.headers["X-GitHub-Event"])
-
-    if not ghrequest.OK:
-        return utils.Response(ghrequest)
-
-    # Get the .pep8speaks.yml config file from the repository
-    config = helpers.get_config(ghrequest.repository, ghrequest.base_branch)
-
-    splitted_comment = ghrequest.comment.lower().split()
-
-    # If diff is required
-    params1 = ["@pep8speaks", "suggest", "diff"]
-    condition1 = all(p in splitted_comment for p in params1)
-    # If asked to pep8ify
-    params2 = ["@pep8speaks", "pep8ify"]
-    condition2 = all(p in splitted_comment for p in params2)
-
-    if condition1:
-        return _create_diff(ghrequest, config)
-    elif condition2:
-        return _pep8ify(ghrequest, config)
-
-    return utils.Response(ghrequest)
 
 
 def handle_unsupported_requests(request):

--- a/pep8speaks/models.py
+++ b/pep8speaks/models.py
@@ -35,7 +35,7 @@ class GHRequest(object):
         if event == "issue_comment":
             pr_url = request.json['issue']['pull_request']['url']
             pull_request = utils._request(pr_url).json()
-        elif event in ("pull_request", "pull_request_review"):
+        elif event == "pull_request":
             pull_request = request.json['pull_request']
         else:
             return None
@@ -87,8 +87,3 @@ class GHRequest(object):
             self.review_url = request.json['comment']['html_url']
             self.comment = request.json['comment']['body']
             self.base_branch = request.json['repository']['default_branch']  # Overrides the default
-
-        if event == 'pull_request_review':
-            self.reviewer = request.json['review']['user']['login']
-            self.review_url = request.json['review']['html_url']
-            self.review_body = request.json['review']['body']

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,8 +12,6 @@ class TestApp:
 
     @pytest.mark.parametrize('event, action', [
         ("pull_request", "handle_pull_request"),
-        ("pull_request_review", "handle_review"),
-        ("pull_request_review_comment", "handle_review_comment"),
         ("integration_installation", "handle_integration_installation"),
         ("integration_installation_repositories", "handle_integration_installation_repo"),
         ("installation_repositories", "handle_integration_installation_repo"),


### PR DESCRIPTION
No user has ever used the Pull Request review area to mention pep8speaks. Removing this will decrease the server load and would make the app more sustainable.