### PR TITLE
Separate default config into a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ only_mention_files_with_errors: True  # If False, a separate status comment for 
 descending_issues_order: False # If True, PEP8 issues in message will be displayed in descending order of line numbers in the file
 ```
 
-Check out the [default configuration options](https://github.com/OrkoHunter/pep8speaks/blob/master/pep8speaks/helpers.py#L87-L115).
+Check out the [default configuration options](https://github.com/OrkoHunter/pep8speaks/blob/master/data/default_config.json).
 
 Note : See more [pycodestyle options](https://pycodestyle.readthedocs.io/en/latest/intro.html#example-usage-and-output)
 

--- a/data/default_config.json
+++ b/data/default_config.json
@@ -1,0 +1,30 @@
+{
+    "message": {
+        "opened": {
+            "header": "",
+            "footer": ""
+        },
+        "updated": {
+            "header": "",
+            "footer": ""
+        },
+        "no_errors": "Cheers ! There are no PEP8 issues in this Pull Request. :beers: "
+    },
+    "scanner": {"diff_only": false},
+    "pycodestyle": {
+        "ignore": [],
+        "max-line-length": 79,
+        "count": false,
+        "first": false,
+        "show-pep8": false,
+        "filename": [],
+        "exclude": [],
+        "select": [],
+        "show-source": false,
+        "statistics": false,
+        "hang-closing": false
+    },
+    "no_blank_comment": true,
+    "only_mention_files_with_errors": true,
+    "descending_issues_order": false
+}

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -45,36 +45,9 @@ def get_config(repo, base_branch):
     """
 
     # Default configuration parameters
-    config = {
-        "message": {
-            "opened": {
-                "header": "",
-                "footer": ""
-            },
-            "updated": {
-                "header": "",
-                "footer": ""
-            },
-            "no_errors": "Cheers ! There are no PEP8 issues in this Pull Request. :beers: ",
-        },
-        "scanner": {"diff_only": False},
-        "pycodestyle": {
-            "ignore": [],
-            "max-line-length": 79,
-            "count": False,
-            "first": False,
-            "show-pep8": False,
-            "filename": [],
-            "exclude": [],
-            "select": [],
-            "show-source": False,
-            "statistics": False,
-            "hang-closing": False,
-        },
-        "no_blank_comment": True,
-        "only_mention_files_with_errors": True,
-        "descending_issues_order": False,
-    }
+    default_config_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'default_config.json')
+    with open(default_config_path) as config_file:
+        config = json.loads(config_file.read())
 
     # Configuration file
     query = "https://raw.githubusercontent.com/{}/{}/.pep8speaks.yml"


### PR DESCRIPTION
The default configuration was hard coded inside the helpers module. Keeping it as a separate file is a better idea and will help refer to it in a more permanent way. (Earlier the line numbers were being used, which kept changing)