### PR TITLE
Use GITHUB_TOKEN instead of BOT_PASSWORD

### DIFF
--- a/pep8speaks/constants.py
+++ b/pep8speaks/constants.py
@@ -2,5 +2,5 @@ import os
 
 # HEADERS is deprecated, use AUTH only
 HEADERS = {"Authorization": "token " + os.environ.setdefault("GITHUB_TOKEN", "")}
-AUTH = (os.environ.setdefault("BOT_USERNAME", ""), os.environ.setdefault("BOT_PASSWORD", ""))
+AUTH = (os.environ.setdefault("BOT_USERNAME", ""), os.environ.setdefault("GITHUB_TOKEN", ""))
 BASE_URL = 'https://api.github.com'


### PR DESCRIPTION
When using BOT_PASSWORD, the bot cannot have
two factor authentication enabled as GitHub expects
an additional header parameter that is the one time
2FA password: https://developer.github.com/v3/auth/#working-with-two-factor-authentication

GITHUB_TOKEN can be used in place of BOT_PASSWORD
in order to correct this. https://developer.github.com/v3/auth/#via-oauth-tokens

Tested on a private organization with 2FA enabled.

Closes https://github.com/OrkoHunter/pep8speaks/issues/78
  