### PR TITLE
Do not fail if expected list config is of NoneType

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -156,7 +156,8 @@ def get_config(repo, base_branch, after_commit_hash):
 
     # linters are case-sensitive with error codes
     for linter in linters:
-        config[linter]["ignore"] = [e.upper() for e in list(config[linter]["ignore"])]
+        if config[linter]["ignore"]:
+            config[linter]["ignore"] = [e.upper() for e in list(config[linter]["ignore"])]
 
     return config
 

--- a/pep8speaks/models.py
+++ b/pep8speaks/models.py
@@ -53,7 +53,7 @@ class GHRequest(object):
             if request['action'] in ['synchronize', 'opened', 'reopened']:
                 return True
         elif event == 'issue_comment':
-            if request['action'] in ('created', 'edited') and 'pull_request' in request.json['issue']:
+            if request['action'] in ('created', 'edited') and 'pull_request' in request['issue']:
                 return True
 
         return False


### PR DESCRIPTION
https://github.com/SwagLyrics/SwagLyrics-For-Spotify/blob/456a5cfae242ca8f7a28a3d849a062b61e9f478c/.pep8speaks.yml#L7-L10
```
flake8:  # Same as scanner.linter value. Other option is flake8
    max-line-length: 120  # Default is 79 in PEP 8
    ignore:  # Errors and warnings to ignore

```

flake8.ignore is supposed to be a list. A config like this in yaml, produces a NoneType and results in error.

Thank you @aadibajpai for raising the issue!