### PR TITLE
Fix "single comment" behavior for non-official deployments

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -397,7 +397,7 @@ def create_or_update_comment(ghrequest, comment, ONLY_UPDATE_COMMENT_BUT_NOT_CRE
     # Get the last comment id by the bot
     last_comment_id = None
     for old_comment in comments:
-        if old_comment["user"]["id"] == 24736507:  # ID of @pep8speaks
+        if old_comment["user"]["login"] == os.environ["BOT_USERNAME"]:
             last_comment_id = old_comment["id"]
             break
 


### PR DESCRIPTION
If updates are made to a pull request and a comment from the bot already exists, that comment should be updated; a new comment should not be added. However, this functionality is broken for non-official deployments -- ie, deployments using a GitHub user other than "pep8speaks". This commit fixes this by using the `BOT_PASSWORD` env var to check for an existing comment, rather than hardcoding the user ID.