### PR TITLE
Add mock to requirements/test.txt

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@
 pytest==3.2.2
 pytest-flask==0.10.0
 pytest-mock==1.6.3
+mock==3.0.5


### PR DESCRIPTION
Without this, on a clean Python 3 virtualenv,
```
pip install -r requirements/test.txt
pytest tests/local
```
yields
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.9, pytest-3.2.2, py-1.8.0, pluggy-0.4.0
rootdir: /home/elliott/pep8speaks, inifile:
plugins: mock-1.6.3, flask-0.10.0
collected 0 items / 2 errors                                                                                                                                                                                                                  

=================================================================================================================== ERRORS ===================================================================================================================
________________________________________________________________________________________________ ERROR collecting tests/local/test_server.py _________________________________________________________________________________________________
ImportError while importing test module '/home/elliott/pep8speaks/tests/local/test_server.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/local/test_server.py:2: in <module>
    import mock
E   ModuleNotFoundError: No module named 'mock'
___________________________________________________________________________________________ ERROR collecting tests/local/pep8speaks/test_utils.py ____________________________________________________________________________________________
ImportError while importing test module '/home/elliott/pep8speaks/tests/local/pep8speaks/test_utils.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/local/pep8speaks/test_utils.py:5: in <module>
    import mock
E   ModuleNotFoundError: No module named 'mock'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================================================================================== 2 error in 0.13 seconds ===========================================================================================================

