### PR TITLE
Fix commands for non-offical deployment

### DIFF
--- a/pep8speaks/handlers.py
+++ b/pep8speaks/handlers.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+
 from pep8speaks import helpers, utils, models
 
 
@@ -76,10 +78,10 @@ def handle_issue_comment(request):
     splitted_comment = ghrequest.comment.lower().split()
 
     # If diff is required
-    params1 = ["@pep8speaks", "suggest", "diff"]
+    params1 = [f"@{os.environ['BOT_USERNAME']}", "suggest", "diff"]
     condition1 = all(p in splitted_comment for p in params1)
     # If asked to pep8ify
-    params2 = ["@pep8speaks", "pep8ify"]
+    params2 = [f"@{os.environ['BOT_USERNAME']}", "pep8ify"]
     condition2 = all(p in splitted_comment for p in params2)
 
     if condition1:
@@ -146,7 +148,7 @@ def _create_diff(ghrequest, config):
         f"Here you go with [the gist]({ghrequest.gist_url}) !\n\n"
         f"> You can ask me to create a PR against this branch "
         f"with those fixes. Simply comment "
-        f"`@pep8speaks pep8ify`.\n\n @{ghrequest.reviewer}"
+        f"`@{os.environ['BOT_USERNAME']} pep8ify`.\n\n @{ghrequest.reviewer}"
     )
     if ghrequest.reviewer != ghrequest.author:  # Both are not the same person
         comment += f" @{ghrequest.author}"

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -356,7 +356,7 @@ def comment_permission_check(ghrequest):
     # # Get the last comment by the bot
     # last_comment = ""
     # for old_comment in reversed(comments):
-    #     if old_comment["user"]["id"] == 24736507:  # ID of @pep8speaks
+    #     if old_comment["user"]["login"] == os.environ["BOT_USERNAME"]:
     #         last_comment = old_comment["body"]
     #         break
 
@@ -368,7 +368,7 @@ def comment_permission_check(ghrequest):
 
     # Check if the bot is asked to keep quiet
     for old_comment in reversed(comments):
-        if '@pep8speaks' in old_comment['body']:
+        if f'@{os.environ["BOT_USERNAME"]}' in old_comment['body']:
             if 'resume' in old_comment['body'].lower():
                 break
             elif 'quiet' in old_comment['body'].lower():


### PR DESCRIPTION
This fixes the `suggest diff` and `pep8ify` commands for non-official deployments (ie where the GitHub user is not "pep8speaks") by checking the BOT_USERNAME env var instead of hardcoding the username.

(draft because this still doesn't seem to work)

UPDATE: OK, part of the issue is I needed to add the `Issue comments` event to the webhook, so I suppose that should be added [here](https://github.com/OrkoHunter/pep8speaks/wiki/Instructions-to-deploy-a-fork#step-4--configure-webhooks). But now I'm hitting the following exception
```
Traceback (most recent call last):
File "/app/.heroku/python/lib/python3.7/site-packages/flask/app.py", line 2292, in wsgi_app
response = self.full_dispatch_request()
File "/app/.heroku/python/lib/python3.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/app/.heroku/python/lib/python3.7/site-packages/flask/app.py", line 1718, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/app/.heroku/python/lib/python3.7/site-packages/flask/_compat.py", line 35, in reraise
raise value
File "/app/.heroku/python/lib/python3.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
rv = self.dispatch_request()
File "/app/.heroku/python/lib/python3.7/site-packages/flask/app.py", line 1799, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/app/server.py", line 38, in main
return event_to_action[event](request)
File "/app/pep8speaks/handlers.py", line 88, in handle_issue_comment
return _create_diff(ghrequest, config)
File "/app/pep8speaks/handlers.py", line 145, in _create_diff
helpers.create_gist(ghrequest)
File "/app/pep8speaks/helpers.py", line 482, in create_gist
ghrequest.gist_url = response["html_url"]
KeyError: 'html_url'
```