### PR TITLE
add support for --per-file-ignores

### DIFF
--- a/data/default_pep8speaks.yml
+++ b/data/default_pep8speaks.yml
@@ -1,5 +1,4 @@
 scanner:
-    diff_only: True  # If False, the entire file touched by the Pull Request is scanned for errors. If True, only the diff is scanned.
     linter: pycodestyle  # Alternative option - flake8
 
 pycodestyle:  # Valid if scanner.linter is pycodestyle
@@ -28,7 +27,6 @@ flake8:  # Valid if scanner.linter is flake8
 
 no_blank_comment: True  # If True, no comment is made on PR without any errors.
 descending_issues_order: False  # If True, PEP 8 issues in message will be displayed in descending order of line numbers in the file
-only_mention_files_with_errors: True  # If False, a separate status section for each file is made in the comment.
 
 message:  # Customize the comment made by the bot
     opened:  # Messages when a new PR is submitted

--- a/pep8speaks/utils.py
+++ b/pep8speaks/utils.py
@@ -39,19 +39,15 @@ def Response(data=None, status=200, mimetype='application/json'):
 def update_dict(base, head):
     """
     Recursively merge or update dict-like objects.
-    >>> update({'k1': 1}, {'k1': {'k2': {'k3': 3}}})
+    >>> update_dict({'k1': 1}, {'k1': {'k2': {'k3': 3}}})
 
-    Source : http://stackoverflow.com/a/32357112/4698026
+    Source : https://stackoverflow.com/a/3233356/11342032
     """
     for key, value in head.items():
-        if key in base:
-            if isinstance(base, collections.Mapping):
-                if isinstance(value, collections.Mapping):
-                    base[key] = update_dict(base.get(key, {}), value)
-                else:
-                    base[key] = head[key]
-            else:
-                base = {key: head[key]}
+        if isinstance(value, collections.Mapping):
+            base[key] = update_dict(base.get(key, {}), value)
+        else:
+            base[key] = value
     return base
 
 


### PR DESCRIPTION
Let me preface this by saying I totally understand if you don't want to merge this, as it makes some fairly substantial changes and removes some options. If so, feel free to close the PR. Just thought I'd offer it up. Even if it doesn't get merged, if others want this feature they can apply this patch.

---

Adds support for flake8's [`--per-file-ignores`](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores)
This required a couple of changes:

- format command line flags for dict-like config values for flake8
  
- rewrite `utils.update_dict`
  In the previous implementation, keys in `head` which do not already
  exist in `base` are not added to `base`. This new implementation is
  from the same Stack Overflow thread as the previous implementation.
  (And is now the top-voted answer.)

  Alternatively, could have just added `per-file-ignores` to
  `data/default_pep8speaks.yml`, but this seems like a better
  long-term solution

- rewrite `helpers.run_pycodestyle`
  Instead of downloading individual files from the pull request, the
  entire repo is downloaded as a zip file, and the linter is run with
  the `--diff` flag. This necessary in order to preserve file paths.

  A consequence of this is the `diff_only` and `only_mention_files_with_errors`
  options are gone -- now, both are always `True`.