### PR TITLE
Deprecare Flask-Session to fix master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: python
 
 python:
-  - 3.6
+  - 3.7
 
 cache:
   directories:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 requests==2.21.0
-Flask-Session==0.3.0
 flask==1.0.2
 gunicorn==19.6.0
 pycodestyle>=2.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 -r base.txt
-pytest==3.2.2
-pytest-flask==0.10.0
+pytest>=5.2
+pytest-flask>=0.15.1
 pytest-mock==1.6.3
 mock==3.0.5

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.2
+python-3.7

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.7.6

--- a/server.py
+++ b/server.py
@@ -4,14 +4,12 @@ import os
 import sys
 
 from flask import Flask, redirect, request
-from flask_session import Session
 
 from pep8speaks import handlers, utils
 
 
 def create_app():
     app = Flask(__name__)
-    sess = Session()
 
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -47,7 +45,6 @@ def create_app():
     app.secret_key = os.environ.setdefault("APP_SECRET_KEY", "")
     app.config['SESSION_TYPE'] = 'filesystem'
 
-    sess.init_app(app)
     app.debug = False
     return app
 


### PR DESCRIPTION
The dependency flask-session is now broken because of a change in `werkzeug` library. https://github.com/fengsp/flask-session/pull/114.
Unfortunately, months have passed but no action has been taken to merge the fix.

PEP8Speaks does not really need Flask-Session and hence, it is better to remove it.

Closes #164 #165 