### PR TITLE
Ensure compatibility with Python 3.9 and later

### DIFF
--- a/pep8speaks/utils.py
+++ b/pep8speaks/utils.py
@@ -1,4 +1,3 @@
-import collections
 import fnmatch
 import hmac
 import json
@@ -8,6 +7,10 @@ from flask import abort
 from flask import Response as FResponse
 import requests
 from pep8speaks.constants import GITHUB_TOKEN, BASE_URL
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 def query_request(query=None, method="GET", **kwargs):
@@ -45,8 +48,8 @@ def update_dict(base, head):
     """
     for key, value in head.items():
         if key in base:
-            if isinstance(base, collections.Mapping):
-                if isinstance(value, collections.Mapping):
+            if isinstance(base, Mapping):
+                if isinstance(value, Mapping):
                     base[key] = update_dict(base.get(key, {}), value)
                 else:
                     base[key] = head[key]


### PR DESCRIPTION
Prior to Python 3.9, the `collections` module contained `Mapping` directly. Starting from Python 3.9, `Mapping` is moved to `collections.abc`. This commit adds a compatibility check to import `Mapping` correctly for Python versions 3.9 and later, ensuring the code works across different Python versions. I also replaced all the instance of `collections.Mapping` to `Mapping`.