### PR TITLE
fix: query request helpers headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#25](https://github.com/njzjz/nodejs-wheel/pull/25#issuecomment-2078310142) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
-2. 🗣 Commented on [#1693](https://github.com/HEXRD/hexrdgui/pull/1693#issuecomment-2078202516) in [HEXRD/hexrdgui](https://github.com/HEXRD/hexrdgui)
-3. 🗣 Commented on [#3](https://github.com/michaelfdickey/my_daily_news/pull/3#issuecomment-2077781293) in [michaelfdickey/my_daily_news](https://github.com/michaelfdickey/my_daily_news)
-4. 🗣 Commented on [#2](https://github.com/michaelfdickey/my_daily_news/pull/2#issuecomment-2077766099) in [michaelfdickey/my_daily_news](https://github.com/michaelfdickey/my_daily_news)
-5. 🗣 Commented on [#2998](https://github.com/astropy/astroquery/pull/2998#issuecomment-2077587980) in [astropy/astroquery](https://github.com/astropy/astroquery)
-6. 🗣 Commented on [#117](https://github.com/eastgenomics/eggd_conductor/pull/117#issuecomment-2077262286) in [eastgenomics/eggd_conductor](https://github.com/eastgenomics/eggd_conductor)
-7. 🗣 Commented on [#2850](https://github.com/metabrainz/listenbrainz-server/pull/2850#issuecomment-2077132820) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
-8. 🗣 Commented on [#194](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/194#issuecomment-2076900350) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
-9. 🗣 Commented on [#24](https://github.com/njzjz/nodejs-wheel/pull/24#issuecomment-2076893615) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
-10. 🗣 Commented on [#2997](https://github.com/astropy/astroquery/pull/2997#issuecomment-2076889746) in [astropy/astroquery](https://github.com/astropy/astroquery)
+1. 🗣 Commented on [#1550](https://github.com/openSUSE/osc/pull/1550#issuecomment-2080062643) in [openSUSE/osc](https://github.com/openSUSE/osc)
+2. 🗣 Commented on [#22027](https://github.com/spyder-ide/spyder/pull/22027#issuecomment-2079557488) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+3. 🗣 Commented on [#986](https://github.com/scilus/scilpy/pull/986#issuecomment-2079507038) in [scilus/scilpy](https://github.com/scilus/scilpy)
+4. 🗣 Commented on [#2855](https://github.com/metabrainz/listenbrainz-server/pull/2855#issuecomment-2079430500) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+5. 🗣 Commented on [#203](https://github.com/eastgenomics/eggd_dias_batch/pull/203#issuecomment-2079401156) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
+6. 🗣 Commented on [#202](https://github.com/eastgenomics/eggd_dias_batch/pull/202#issuecomment-2079400986) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
+7. 🗣 Commented on [#200](https://github.com/eastgenomics/eggd_dias_batch/pull/200#issuecomment-2079400710) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
+8. 🗣 Commented on [#82](https://github.com/eastgenomics/trendyQC/pull/82#issuecomment-2079371531) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+9. 🗣 Commented on [#495](https://github.com/Spoken-tutorial/spoken-website/pull/495#issuecomment-2079124078) in [Spoken-tutorial/spoken-website](https://github.com/Spoken-tutorial/spoken-website)
+10. 🗣 Commented on [#1497](https://github.com/rpm-software-management/ci-dnf-stack/pull/1497#issuecomment-2079007402) in [rpm-software-management/ci-dnf-stack](https://github.com/rpm-software-management/ci-dnf-stack)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#34](https://github.com/jcmgray/cotengra/pull/34#issuecomment-2059980447) in [jcmgray/cotengra](https://github.com/jcmgray/cotengra)
-2. 🗣 Commented on [#633](https://github.com/HEXRD/hexrd/pull/633#issuecomment-2059914275) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-3. 🗣 Commented on [#972](https://github.com/scilus/scilpy/pull/972#issuecomment-2059668915) in [scilus/scilpy](https://github.com/scilus/scilpy)
-4. 🗣 Commented on [#763](https://github.com/minerllabs/minerl/pull/763#issuecomment-2059542091) in [minerllabs/minerl](https://github.com/minerllabs/minerl)
-5. 🗣 Commented on [#504](https://github.com/oemof/tespy/pull/504#issuecomment-2059525068) in [oemof/tespy](https://github.com/oemof/tespy)
-6. 🗣 Commented on [#8](https://github.com/alexfore/ARIA-tools/pull/8#issuecomment-2059501781) in [alexfore/ARIA-tools](https://github.com/alexfore/ARIA-tools)
-7. 🗣 Commented on [#5571](https://github.com/rhinstaller/anaconda/pull/5571#issuecomment-2059478301) in [rhinstaller/anaconda](https://github.com/rhinstaller/anaconda)
-8. 🗣 Commented on [#7](https://github.com/alexfore/ARIA-tools/pull/7#issuecomment-2059478059) in [alexfore/ARIA-tools](https://github.com/alexfore/ARIA-tools)
-9. 🗣 Commented on [#60](https://github.com/eastgenomics/Genetics_Ark/pull/60#issuecomment-2059325957) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
-10. 🗣 Commented on [#5570](https://github.com/rhinstaller/anaconda/pull/5570#issuecomment-2059275992) in [rhinstaller/anaconda](https://github.com/rhinstaller/anaconda)
+1. 🗣 Commented on [#22005](https://github.com/spyder-ide/spyder/pull/22005#issuecomment-2062510487) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+2. 🗣 Commented on [#3194](https://github.com/dipy/dipy/pull/3194#issuecomment-2062351682) in [dipy/dipy](https://github.com/dipy/dipy)
+3. 🗣 Commented on [#1129](https://github.com/yeatmanlab/pyAFQ/pull/1129#issuecomment-2062272758) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
+4. 🗣 Commented on [#307](https://github.com/OpenFreeEnergy/gufe/pull/307#issuecomment-2062103152) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
+5. 🗣 Commented on [#306](https://github.com/OpenFreeEnergy/gufe/pull/306#issuecomment-2062085505) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
+6. 🗣 Commented on [#42](https://github.com/OpenFreeEnergy/kartograf/pull/42#issuecomment-2061971668) in [OpenFreeEnergy/kartograf](https://github.com/OpenFreeEnergy/kartograf)
+7. 🗣 Commented on [#492](https://github.com/VorTECHsa/python-sdk/pull/492#issuecomment-2061800620) in [VorTECHsa/python-sdk](https://github.com/VorTECHsa/python-sdk)
+8. 🗣 Commented on [#976](https://github.com/scilus/scilpy/pull/976#issuecomment-2061799234) in [scilus/scilpy](https://github.com/scilus/scilpy)
+9. 🗣 Commented on [#192](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/192#issuecomment-2061652449) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
+10. 🗣 Commented on [#64](https://github.com/eastgenomics/Genetics_Ark/pull/64#issuecomment-2061495561) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#212](https://github.com/Fatal1ty/mashumaro/pull/212#issuecomment-2065070135) in [Fatal1ty/mashumaro](https://github.com/Fatal1ty/mashumaro)
-2. 🗣 Commented on [#1544](https://github.com/spacetelescope/jwql/pull/1544#issuecomment-2064994599) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
-3. 🗣 Commented on [#304](https://github.com/AdvancedPhotonSource/tike/pull/304#issuecomment-2064390452) in [AdvancedPhotonSource/tike](https://github.com/AdvancedPhotonSource/tike)
-4. 🗣 Commented on [#1684](https://github.com/OGGM/oggm/pull/1684#issuecomment-2064270238) in [OGGM/oggm](https://github.com/OGGM/oggm)
-5. 🗣 Commented on [#72](https://github.com/eastgenomics/trendyQC/pull/72#issuecomment-2063884354) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-6. 🗣 Commented on [#65](https://github.com/eastgenomics/Genetics_Ark/pull/65#issuecomment-2063359408) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
-7. 🗣 Commented on [#22006](https://github.com/spyder-ide/spyder/pull/22006#issuecomment-2062760737) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
-8. 🗣 Commented on [#22005](https://github.com/spyder-ide/spyder/pull/22005#issuecomment-2062510487) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
-9. 🗣 Commented on [#3194](https://github.com/dipy/dipy/pull/3194#issuecomment-2062351682) in [dipy/dipy](https://github.com/dipy/dipy)
-10. 🗣 Commented on [#1129](https://github.com/yeatmanlab/pyAFQ/pull/1129#issuecomment-2062272758) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
+1. 🗣 Commented on [#926](https://github.com/ToFuProject/tofu/pull/926#issuecomment-2067217046) in [ToFuProject/tofu](https://github.com/ToFuProject/tofu)
+2. 🗣 Commented on [#635](https://github.com/HEXRD/hexrd/pull/635#issuecomment-2066808038) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+3. 🗣 Commented on [#633](https://github.com/NeuralEnsemble/elephant/pull/633#issuecomment-2066750478) in [NeuralEnsemble/elephant](https://github.com/NeuralEnsemble/elephant)
+4. 🗣 Commented on [#74](https://github.com/eastgenomics/trendyQC/pull/74#issuecomment-2066207044) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+5. 🗣 Commented on [#1542](https://github.com/openSUSE/osc/pull/1542#issuecomment-2066181143) in [openSUSE/osc](https://github.com/openSUSE/osc)
+6. 🗣 Commented on [#115](https://github.com/eastgenomics/eggd_conductor/pull/115#issuecomment-2066149889) in [eastgenomics/eggd_conductor](https://github.com/eastgenomics/eggd_conductor)
+7. 🗣 Commented on [#634](https://github.com/HEXRD/hexrd/pull/634#issuecomment-2065691825) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+8. 🗣 Commented on [#212](https://github.com/Fatal1ty/mashumaro/pull/212#issuecomment-2065070135) in [Fatal1ty/mashumaro](https://github.com/Fatal1ty/mashumaro)
+9. 🗣 Commented on [#1544](https://github.com/spacetelescope/jwql/pull/1544#issuecomment-2064994599) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
+10. 🗣 Commented on [#304](https://github.com/AdvancedPhotonSource/tike/pull/304#issuecomment-2064390452) in [AdvancedPhotonSource/tike](https://github.com/AdvancedPhotonSource/tike)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#926](https://github.com/ToFuProject/tofu/pull/926#issuecomment-2067217046) in [ToFuProject/tofu](https://github.com/ToFuProject/tofu)
-2. 🗣 Commented on [#635](https://github.com/HEXRD/hexrd/pull/635#issuecomment-2066808038) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-3. 🗣 Commented on [#633](https://github.com/NeuralEnsemble/elephant/pull/633#issuecomment-2066750478) in [NeuralEnsemble/elephant](https://github.com/NeuralEnsemble/elephant)
-4. 🗣 Commented on [#74](https://github.com/eastgenomics/trendyQC/pull/74#issuecomment-2066207044) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-5. 🗣 Commented on [#1542](https://github.com/openSUSE/osc/pull/1542#issuecomment-2066181143) in [openSUSE/osc](https://github.com/openSUSE/osc)
-6. 🗣 Commented on [#115](https://github.com/eastgenomics/eggd_conductor/pull/115#issuecomment-2066149889) in [eastgenomics/eggd_conductor](https://github.com/eastgenomics/eggd_conductor)
-7. 🗣 Commented on [#634](https://github.com/HEXRD/hexrd/pull/634#issuecomment-2065691825) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-8. 🗣 Commented on [#212](https://github.com/Fatal1ty/mashumaro/pull/212#issuecomment-2065070135) in [Fatal1ty/mashumaro](https://github.com/Fatal1ty/mashumaro)
-9. 🗣 Commented on [#1544](https://github.com/spacetelescope/jwql/pull/1544#issuecomment-2064994599) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
-10. 🗣 Commented on [#304](https://github.com/AdvancedPhotonSource/tike/pull/304#issuecomment-2064390452) in [AdvancedPhotonSource/tike](https://github.com/AdvancedPhotonSource/tike)
+1. 🗣 Commented on [#3197](https://github.com/dipy/dipy/pull/3197#issuecomment-2067705261) in [dipy/dipy](https://github.com/dipy/dipy)
+2. 🗣 Commented on [#59](https://github.com/autonomio/astetik/pull/59#issuecomment-2067690861) in [autonomio/astetik](https://github.com/autonomio/astetik)
+3. 🗣 Commented on [#598](https://github.com/autonomio/talos/pull/598#issuecomment-2067687587) in [autonomio/talos](https://github.com/autonomio/talos)
+4. 🗣 Commented on [#819](https://github.com/StingraySoftware/stingray/pull/819#issuecomment-2067626714) in [StingraySoftware/stingray](https://github.com/StingraySoftware/stingray)
+5. 🗣 Commented on [#3196](https://github.com/dipy/dipy/pull/3196#issuecomment-2067576657) in [dipy/dipy](https://github.com/dipy/dipy)
+6. 🗣 Commented on [#926](https://github.com/ToFuProject/tofu/pull/926#issuecomment-2067217046) in [ToFuProject/tofu](https://github.com/ToFuProject/tofu)
+7. 🗣 Commented on [#635](https://github.com/HEXRD/hexrd/pull/635#issuecomment-2066808038) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+8. 🗣 Commented on [#633](https://github.com/NeuralEnsemble/elephant/pull/633#issuecomment-2066750478) in [NeuralEnsemble/elephant](https://github.com/NeuralEnsemble/elephant)
+9. 🗣 Commented on [#74](https://github.com/eastgenomics/trendyQC/pull/74#issuecomment-2066207044) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+10. 🗣 Commented on [#1542](https://github.com/openSUSE/osc/pull/1542#issuecomment-2066181143) in [openSUSE/osc](https://github.com/openSUSE/osc)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
-2. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
-3. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
-4. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
-5. 🗣 Commented on [#2834](https://github.com/metabrainz/listenbrainz-server/pull/2834#issuecomment-2052040367) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
-6. 🗣 Commented on [#147](https://github.com/DeMarcoLab/autolamella/pull/147#issuecomment-2051218661) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
-7. 🗣 Commented on [#1](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast/pull/1#issuecomment-2050705564) in [Mr-Sunglasses/FastApi-Learn-Fast](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast)
-8. 🗣 Commented on [#395](https://github.com/poldracklab/fitlins/pull/395#issuecomment-2050650570) in [poldracklab/fitlins](https://github.com/poldracklab/fitlins)
-9. 🗣 Commented on [#1790](https://github.com/zarr-developers/zarr-python/pull/1790#issuecomment-2050398422) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-10. 🗣 Commented on [#1785](https://github.com/zarr-developers/zarr-python/pull/1785#issuecomment-2050355058) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
+1. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
+2. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
+3. 🗣 Commented on [#3](https://github.com/cdfxscrq/MyTelegramOrgRoBot/pull/3#issuecomment-2053714065) in [cdfxscrq/MyTelegramOrgRoBot](https://github.com/cdfxscrq/MyTelegramOrgRoBot)
+4. 🗣 Commented on [#631](https://github.com/HEXRD/hexrd/pull/631#issuecomment-2053606917) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+5. 🗣 Commented on [#209](https://github.com/njzjz/deepmd-kit/pull/209#issuecomment-2052922893) in [njzjz/deepmd-kit](https://github.com/njzjz/deepmd-kit)
+6. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
+7. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
+8. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
+9. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
+10. 🗣 Commented on [#2834](https://github.com/metabrainz/listenbrainz-server/pull/2834#issuecomment-2052040367) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#502](https://github.com/oemof/tespy/pull/502#issuecomment-2057924608) in [oemof/tespy](https://github.com/oemof/tespy)
-2. 🗣 Commented on [#1541](https://github.com/spacetelescope/jwql/pull/1541#issuecomment-2057694211) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
-3. 🗣 Commented on [#114](https://github.com/TIGRLab/datman-dashboard/pull/114#issuecomment-2057473790) in [TIGRLab/datman-dashboard](https://github.com/TIGRLab/datman-dashboard)
-4. 🗣 Commented on [#3158](https://github.com/reframe-hpc/reframe/pull/3158#issuecomment-2057383579) in [reframe-hpc/reframe](https://github.com/reframe-hpc/reframe)
-5. 🗣 Commented on [#1536](https://github.com/openSUSE/osc/pull/1536#issuecomment-2057047173) in [openSUSE/osc](https://github.com/openSUSE/osc)
-6. 🗣 Commented on [#57](https://github.com/eastgenomics/Genetics_Ark/pull/57#issuecomment-2056898482) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
-7. 🗣 Commented on [#1383](https://github.com/deepfakes/faceswap/pull/1383#issuecomment-2056546396) in [deepfakes/faceswap](https://github.com/deepfakes/faceswap)
-8. 🗣 Commented on [#50](https://github.com/codingfriendsfun/pcc/pull/50#issuecomment-2053860585) in [codingfriendsfun/pcc](https://github.com/codingfriendsfun/pcc)
-9. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
-10. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
+1. 🗣 Commented on [#34](https://github.com/jcmgray/cotengra/pull/34#issuecomment-2059980447) in [jcmgray/cotengra](https://github.com/jcmgray/cotengra)
+2. 🗣 Commented on [#633](https://github.com/HEXRD/hexrd/pull/633#issuecomment-2059914275) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+3. 🗣 Commented on [#972](https://github.com/scilus/scilpy/pull/972#issuecomment-2059668915) in [scilus/scilpy](https://github.com/scilus/scilpy)
+4. 🗣 Commented on [#763](https://github.com/minerllabs/minerl/pull/763#issuecomment-2059542091) in [minerllabs/minerl](https://github.com/minerllabs/minerl)
+5. 🗣 Commented on [#504](https://github.com/oemof/tespy/pull/504#issuecomment-2059525068) in [oemof/tespy](https://github.com/oemof/tespy)
+6. 🗣 Commented on [#8](https://github.com/alexfore/ARIA-tools/pull/8#issuecomment-2059501781) in [alexfore/ARIA-tools](https://github.com/alexfore/ARIA-tools)
+7. 🗣 Commented on [#5571](https://github.com/rhinstaller/anaconda/pull/5571#issuecomment-2059478301) in [rhinstaller/anaconda](https://github.com/rhinstaller/anaconda)
+8. 🗣 Commented on [#7](https://github.com/alexfore/ARIA-tools/pull/7#issuecomment-2059478059) in [alexfore/ARIA-tools](https://github.com/alexfore/ARIA-tools)
+9. 🗣 Commented on [#60](https://github.com/eastgenomics/Genetics_Ark/pull/60#issuecomment-2059325957) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+10. 🗣 Commented on [#5570](https://github.com/rhinstaller/anaconda/pull/5570#issuecomment-2059275992) in [rhinstaller/anaconda](https://github.com/rhinstaller/anaconda)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#1790](https://github.com/zarr-developers/zarr-python/pull/1790#issuecomment-2050398422) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-2. 🗣 Commented on [#1785](https://github.com/zarr-developers/zarr-python/pull/1785#issuecomment-2050355058) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-3. 🗣 Commented on [#3156](https://github.com/reframe-hpc/reframe/pull/3156#issuecomment-2049917685) in [reframe-hpc/reframe](https://github.com/reframe-hpc/reframe)
-4. 🗣 Commented on [#1124](https://github.com/yeatmanlab/pyAFQ/pull/1124#issuecomment-2048122686) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
-5. 🗣 Commented on [#9191](https://github.com/statsmodels/statsmodels/pull/9191#issuecomment-2048069393) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
-6. 🗣 Commented on [#1083](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1083#issuecomment-2048039209) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
-7. 🗣 Commented on [#304](https://github.com/OpenFreeEnergy/gufe/pull/304#issuecomment-2047805880) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
-8. 🗣 Commented on [#5](https://github.com/eastgenomics/eggd_add_MANE_annotation/pull/5#issuecomment-2047484088) in [eastgenomics/eggd_add_MANE_annotation](https://github.com/eastgenomics/eggd_add_MANE_annotation)
-9. 🗣 Commented on [#3903](https://github.com/privacyidea/privacyidea/pull/3903#issuecomment-2047187624) in [privacyidea/privacyidea](https://github.com/privacyidea/privacyidea)
-10. 🗣 Commented on [#5](https://github.com/eastgenomics/eggd_sex_check/pull/5#issuecomment-2047057072) in [eastgenomics/eggd_sex_check](https://github.com/eastgenomics/eggd_sex_check)
+1. 🗣 Commented on [#1](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast/pull/1#issuecomment-2050705564) in [Mr-Sunglasses/FastApi-Learn-Fast](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast)
+2. 🗣 Commented on [#395](https://github.com/poldracklab/fitlins/pull/395#issuecomment-2050650570) in [poldracklab/fitlins](https://github.com/poldracklab/fitlins)
+3. 🗣 Commented on [#1790](https://github.com/zarr-developers/zarr-python/pull/1790#issuecomment-2050398422) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
+4. 🗣 Commented on [#1785](https://github.com/zarr-developers/zarr-python/pull/1785#issuecomment-2050355058) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
+5. 🗣 Commented on [#3156](https://github.com/reframe-hpc/reframe/pull/3156#issuecomment-2049917685) in [reframe-hpc/reframe](https://github.com/reframe-hpc/reframe)
+6. 🗣 Commented on [#1124](https://github.com/yeatmanlab/pyAFQ/pull/1124#issuecomment-2048122686) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
+7. 🗣 Commented on [#9191](https://github.com/statsmodels/statsmodels/pull/9191#issuecomment-2048069393) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
+8. 🗣 Commented on [#1083](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1083#issuecomment-2048039209) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
+9. 🗣 Commented on [#304](https://github.com/OpenFreeEnergy/gufe/pull/304#issuecomment-2047805880) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
+10. 🗣 Commented on [#5](https://github.com/eastgenomics/eggd_add_MANE_annotation/pull/5#issuecomment-2047484088) in [eastgenomics/eggd_add_MANE_annotation](https://github.com/eastgenomics/eggd_add_MANE_annotation)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
-2. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
-3. 🗣 Commented on [#3](https://github.com/cdfxscrq/MyTelegramOrgRoBot/pull/3#issuecomment-2053714065) in [cdfxscrq/MyTelegramOrgRoBot](https://github.com/cdfxscrq/MyTelegramOrgRoBot)
-4. 🗣 Commented on [#631](https://github.com/HEXRD/hexrd/pull/631#issuecomment-2053606917) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-5. 🗣 Commented on [#209](https://github.com/njzjz/deepmd-kit/pull/209#issuecomment-2052922893) in [njzjz/deepmd-kit](https://github.com/njzjz/deepmd-kit)
-6. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
-7. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
-8. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
-9. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
-10. 🗣 Commented on [#2834](https://github.com/metabrainz/listenbrainz-server/pull/2834#issuecomment-2052040367) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+1. 🗣 Commented on [#50](https://github.com/codingfriendsfun/pcc/pull/50#issuecomment-2053860585) in [codingfriendsfun/pcc](https://github.com/codingfriendsfun/pcc)
+2. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
+3. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
+4. 🗣 Commented on [#3](https://github.com/cdfxscrq/MyTelegramOrgRoBot/pull/3#issuecomment-2053714065) in [cdfxscrq/MyTelegramOrgRoBot](https://github.com/cdfxscrq/MyTelegramOrgRoBot)
+5. 🗣 Commented on [#631](https://github.com/HEXRD/hexrd/pull/631#issuecomment-2053606917) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
+6. 🗣 Commented on [#209](https://github.com/njzjz/deepmd-kit/pull/209#issuecomment-2052922893) in [njzjz/deepmd-kit](https://github.com/njzjz/deepmd-kit)
+7. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
+8. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
+9. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
+10. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#398](https://github.com/aria-tools/ARIA-tools/pull/398#issuecomment-2070313074) in [aria-tools/ARIA-tools](https://github.com/aria-tools/ARIA-tools)
-2. 🗣 Commented on [#1](https://github.com/eastgenomics/eggd_generate_wgs_solid_cancer_workbook/pull/1#issuecomment-2069344028) in [eastgenomics/eggd_generate_wgs_solid_cancer_workbook](https://github.com/eastgenomics/eggd_generate_wgs_solid_cancer_workbook)
-3. 🗣 Commented on [#79](https://github.com/eastgenomics/trendyQC/pull/79#issuecomment-2069211982) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-4. 🗣 Commented on [#77](https://github.com/eastgenomics/trendyQC/pull/77#issuecomment-2069173824) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-5. 🗣 Commented on [#1544](https://github.com/openSUSE/osc/pull/1544#issuecomment-2069163440) in [openSUSE/osc](https://github.com/openSUSE/osc)
-6. 🗣 Commented on [#76](https://github.com/eastgenomics/trendyQC/pull/76#issuecomment-2069080530) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-7. 🗣 Commented on [#1804](https://github.com/zarr-developers/zarr-python/pull/1804#issuecomment-2069055066) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-8. 🗣 Commented on [#968](https://github.com/avaframe/AvaFrame/pull/968#issuecomment-2069000072) in [avaframe/AvaFrame](https://github.com/avaframe/AvaFrame)
-9. 🗣 Commented on [#75](https://github.com/eastgenomics/trendyQC/pull/75#issuecomment-2068992261) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-10. 🗣 Commented on [#226](https://github.com/OpenSCAP/openscap-report/pull/226#issuecomment-2068852199) in [OpenSCAP/openscap-report](https://github.com/OpenSCAP/openscap-report)
+1. 🗣 Commented on [#42](https://github.com/NASA-Planetary-Science/AmesCAP/pull/42#issuecomment-2073427635) in [NASA-Planetary-Science/AmesCAP](https://github.com/NASA-Planetary-Science/AmesCAP)
+2. 🗣 Commented on [#985](https://github.com/scilus/scilpy/pull/985#issuecomment-2073279393) in [scilus/scilpy](https://github.com/scilus/scilpy)
+3. 🗣 Commented on [#19](https://github.com/arfc/openmcyclus/pull/19#issuecomment-2072837495) in [arfc/openmcyclus](https://github.com/arfc/openmcyclus)
+4. 🗣 Commented on [#9227](https://github.com/statsmodels/statsmodels/pull/9227#issuecomment-2072832686) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
+5. 🗣 Commented on [#984](https://github.com/scilus/scilpy/pull/984#issuecomment-2072731267) in [scilus/scilpy](https://github.com/scilus/scilpy)
+6. 🗣 Commented on [#26](https://github.com/Moonlark-Dev/Moonlark/pull/26#issuecomment-2072720132) in [Moonlark-Dev/Moonlark](https://github.com/Moonlark-Dev/Moonlark)
+7. 🗣 Commented on [#561](https://github.com/aramis-lab/clinicadl/pull/561#issuecomment-2072333320) in [aramis-lab/clinicadl](https://github.com/aramis-lab/clinicadl)
+8. 🗣 Commented on [#3911](https://github.com/privacyidea/privacyidea/pull/3911#issuecomment-2072313319) in [privacyidea/privacyidea](https://github.com/privacyidea/privacyidea)
+9. 🗣 Commented on [#2995](https://github.com/astropy/astroquery/pull/2995#issuecomment-2072115446) in [astropy/astroquery](https://github.com/astropy/astroquery)
+10. 🗣 Commented on [#66](https://github.com/eastgenomics/Genetics_Ark/pull/66#issuecomment-2072063311) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#3197](https://github.com/dipy/dipy/pull/3197#issuecomment-2067705261) in [dipy/dipy](https://github.com/dipy/dipy)
-2. 🗣 Commented on [#59](https://github.com/autonomio/astetik/pull/59#issuecomment-2067690861) in [autonomio/astetik](https://github.com/autonomio/astetik)
-3. 🗣 Commented on [#598](https://github.com/autonomio/talos/pull/598#issuecomment-2067687587) in [autonomio/talos](https://github.com/autonomio/talos)
-4. 🗣 Commented on [#819](https://github.com/StingraySoftware/stingray/pull/819#issuecomment-2067626714) in [StingraySoftware/stingray](https://github.com/StingraySoftware/stingray)
-5. 🗣 Commented on [#3196](https://github.com/dipy/dipy/pull/3196#issuecomment-2067576657) in [dipy/dipy](https://github.com/dipy/dipy)
-6. 🗣 Commented on [#926](https://github.com/ToFuProject/tofu/pull/926#issuecomment-2067217046) in [ToFuProject/tofu](https://github.com/ToFuProject/tofu)
-7. 🗣 Commented on [#635](https://github.com/HEXRD/hexrd/pull/635#issuecomment-2066808038) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-8. 🗣 Commented on [#633](https://github.com/NeuralEnsemble/elephant/pull/633#issuecomment-2066750478) in [NeuralEnsemble/elephant](https://github.com/NeuralEnsemble/elephant)
-9. 🗣 Commented on [#74](https://github.com/eastgenomics/trendyQC/pull/74#issuecomment-2066207044) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-10. 🗣 Commented on [#1542](https://github.com/openSUSE/osc/pull/1542#issuecomment-2066181143) in [openSUSE/osc](https://github.com/openSUSE/osc)
+1. 🗣 Commented on [#398](https://github.com/aria-tools/ARIA-tools/pull/398#issuecomment-2070313074) in [aria-tools/ARIA-tools](https://github.com/aria-tools/ARIA-tools)
+2. 🗣 Commented on [#1](https://github.com/eastgenomics/eggd_generate_wgs_solid_cancer_workbook/pull/1#issuecomment-2069344028) in [eastgenomics/eggd_generate_wgs_solid_cancer_workbook](https://github.com/eastgenomics/eggd_generate_wgs_solid_cancer_workbook)
+3. 🗣 Commented on [#79](https://github.com/eastgenomics/trendyQC/pull/79#issuecomment-2069211982) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+4. 🗣 Commented on [#77](https://github.com/eastgenomics/trendyQC/pull/77#issuecomment-2069173824) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+5. 🗣 Commented on [#1544](https://github.com/openSUSE/osc/pull/1544#issuecomment-2069163440) in [openSUSE/osc](https://github.com/openSUSE/osc)
+6. 🗣 Commented on [#76](https://github.com/eastgenomics/trendyQC/pull/76#issuecomment-2069080530) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+7. 🗣 Commented on [#1804](https://github.com/zarr-developers/zarr-python/pull/1804#issuecomment-2069055066) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
+8. 🗣 Commented on [#968](https://github.com/avaframe/AvaFrame/pull/968#issuecomment-2069000072) in [avaframe/AvaFrame](https://github.com/avaframe/AvaFrame)
+9. 🗣 Commented on [#75](https://github.com/eastgenomics/trendyQC/pull/75#issuecomment-2068992261) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+10. 🗣 Commented on [#226](https://github.com/OpenSCAP/openscap-report/pull/226#issuecomment-2068852199) in [OpenSCAP/openscap-report](https://github.com/OpenSCAP/openscap-report)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#882](https://github.com/fury-gl/fury/pull/882#issuecomment-2081184806) in [fury-gl/fury](https://github.com/fury-gl/fury)
-2. 🗣 Commented on [#9235](https://github.com/statsmodels/statsmodels/pull/9235#issuecomment-2080915687) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
-3. 🗣 Commented on [#315](https://github.com/OpenFreeEnergy/gufe/pull/315#issuecomment-2080411439) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
-4. 🗣 Commented on [#26](https://github.com/njzjz/nodejs-wheel/pull/26#issuecomment-2080358896) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
-5. 🗣 Commented on [#1550](https://github.com/openSUSE/osc/pull/1550#issuecomment-2080062643) in [openSUSE/osc](https://github.com/openSUSE/osc)
-6. 🗣 Commented on [#22027](https://github.com/spyder-ide/spyder/pull/22027#issuecomment-2079557488) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
-7. 🗣 Commented on [#986](https://github.com/scilus/scilpy/pull/986#issuecomment-2079507038) in [scilus/scilpy](https://github.com/scilus/scilpy)
-8. 🗣 Commented on [#2855](https://github.com/metabrainz/listenbrainz-server/pull/2855#issuecomment-2079430500) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
-9. 🗣 Commented on [#203](https://github.com/eastgenomics/eggd_dias_batch/pull/203#issuecomment-2079401156) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
-10. 🗣 Commented on [#202](https://github.com/eastgenomics/eggd_dias_batch/pull/202#issuecomment-2079400986) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
+1. 🗣 Commented on [#22](https://github.com/brianhang/pokerpals/pull/22#issuecomment-2081702249) in [brianhang/pokerpals](https://github.com/brianhang/pokerpals)
+2. 🗣 Commented on [#28](https://github.com/CartoonFan/libloot/pull/28#issuecomment-2081505473) in [CartoonFan/libloot](https://github.com/CartoonFan/libloot)
+3. 🗣 Commented on [#882](https://github.com/fury-gl/fury/pull/882#issuecomment-2081184806) in [fury-gl/fury](https://github.com/fury-gl/fury)
+4. 🗣 Commented on [#9235](https://github.com/statsmodels/statsmodels/pull/9235#issuecomment-2080915687) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
+5. 🗣 Commented on [#315](https://github.com/OpenFreeEnergy/gufe/pull/315#issuecomment-2080411439) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
+6. 🗣 Commented on [#26](https://github.com/njzjz/nodejs-wheel/pull/26#issuecomment-2080358896) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
+7. 🗣 Commented on [#1550](https://github.com/openSUSE/osc/pull/1550#issuecomment-2080062643) in [openSUSE/osc](https://github.com/openSUSE/osc)
+8. 🗣 Commented on [#22027](https://github.com/spyder-ide/spyder/pull/22027#issuecomment-2079557488) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+9. 🗣 Commented on [#986](https://github.com/scilus/scilpy/pull/986#issuecomment-2079507038) in [scilus/scilpy](https://github.com/scilus/scilpy)
+10. 🗣 Commented on [#2855](https://github.com/metabrainz/listenbrainz-server/pull/2855#issuecomment-2079430500) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#42](https://github.com/NASA-Planetary-Science/AmesCAP/pull/42#issuecomment-2073427635) in [NASA-Planetary-Science/AmesCAP](https://github.com/NASA-Planetary-Science/AmesCAP)
-2. 🗣 Commented on [#985](https://github.com/scilus/scilpy/pull/985#issuecomment-2073279393) in [scilus/scilpy](https://github.com/scilus/scilpy)
-3. 🗣 Commented on [#19](https://github.com/arfc/openmcyclus/pull/19#issuecomment-2072837495) in [arfc/openmcyclus](https://github.com/arfc/openmcyclus)
-4. 🗣 Commented on [#9227](https://github.com/statsmodels/statsmodels/pull/9227#issuecomment-2072832686) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
-5. 🗣 Commented on [#984](https://github.com/scilus/scilpy/pull/984#issuecomment-2072731267) in [scilus/scilpy](https://github.com/scilus/scilpy)
-6. 🗣 Commented on [#26](https://github.com/Moonlark-Dev/Moonlark/pull/26#issuecomment-2072720132) in [Moonlark-Dev/Moonlark](https://github.com/Moonlark-Dev/Moonlark)
-7. 🗣 Commented on [#561](https://github.com/aramis-lab/clinicadl/pull/561#issuecomment-2072333320) in [aramis-lab/clinicadl](https://github.com/aramis-lab/clinicadl)
-8. 🗣 Commented on [#3911](https://github.com/privacyidea/privacyidea/pull/3911#issuecomment-2072313319) in [privacyidea/privacyidea](https://github.com/privacyidea/privacyidea)
-9. 🗣 Commented on [#2995](https://github.com/astropy/astroquery/pull/2995#issuecomment-2072115446) in [astropy/astroquery](https://github.com/astropy/astroquery)
-10. 🗣 Commented on [#66](https://github.com/eastgenomics/Genetics_Ark/pull/66#issuecomment-2072063311) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+1. 🗣 Commented on [#399](https://github.com/aria-tools/ARIA-tools/pull/399#issuecomment-2075999490) in [aria-tools/ARIA-tools](https://github.com/aria-tools/ARIA-tools)
+2. 🗣 Commented on [#2848](https://github.com/metabrainz/listenbrainz-server/pull/2848#issuecomment-2075176175) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+3. 🗣 Commented on [#560](https://github.com/aramis-lab/clinicadl/pull/560#issuecomment-2075156211) in [aramis-lab/clinicadl](https://github.com/aramis-lab/clinicadl)
+4. 🗣 Commented on [#193](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/193#issuecomment-2075069354) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
+5. 🗣 Commented on [#880](https://github.com/fury-gl/fury/pull/880#issuecomment-2074806312) in [fury-gl/fury](https://github.com/fury-gl/fury)
+6. 🗣 Commented on [#491](https://github.com/Spoken-tutorial/spoken-website/pull/491#issuecomment-2074718051) in [Spoken-tutorial/spoken-website](https://github.com/Spoken-tutorial/spoken-website)
+7. 🗣 Commented on [#81](https://github.com/eastgenomics/trendyQC/pull/81#issuecomment-2074600145) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+8. 🗣 Commented on [#68](https://github.com/eastgenomics/Genetics_Ark/pull/68#issuecomment-2074464978) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+9. 🗣 Commented on [#42](https://github.com/NASA-Planetary-Science/AmesCAP/pull/42#issuecomment-2073427635) in [NASA-Planetary-Science/AmesCAP](https://github.com/NASA-Planetary-Science/AmesCAP)
+10. 🗣 Commented on [#985](https://github.com/scilus/scilpy/pull/985#issuecomment-2073279393) in [scilus/scilpy](https://github.com/scilus/scilpy)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#399](https://github.com/aria-tools/ARIA-tools/pull/399#issuecomment-2075999490) in [aria-tools/ARIA-tools](https://github.com/aria-tools/ARIA-tools)
-2. 🗣 Commented on [#2848](https://github.com/metabrainz/listenbrainz-server/pull/2848#issuecomment-2075176175) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
-3. 🗣 Commented on [#560](https://github.com/aramis-lab/clinicadl/pull/560#issuecomment-2075156211) in [aramis-lab/clinicadl](https://github.com/aramis-lab/clinicadl)
-4. 🗣 Commented on [#193](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/193#issuecomment-2075069354) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
-5. 🗣 Commented on [#880](https://github.com/fury-gl/fury/pull/880#issuecomment-2074806312) in [fury-gl/fury](https://github.com/fury-gl/fury)
-6. 🗣 Commented on [#491](https://github.com/Spoken-tutorial/spoken-website/pull/491#issuecomment-2074718051) in [Spoken-tutorial/spoken-website](https://github.com/Spoken-tutorial/spoken-website)
-7. 🗣 Commented on [#81](https://github.com/eastgenomics/trendyQC/pull/81#issuecomment-2074600145) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-8. 🗣 Commented on [#68](https://github.com/eastgenomics/Genetics_Ark/pull/68#issuecomment-2074464978) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
-9. 🗣 Commented on [#42](https://github.com/NASA-Planetary-Science/AmesCAP/pull/42#issuecomment-2073427635) in [NASA-Planetary-Science/AmesCAP](https://github.com/NASA-Planetary-Science/AmesCAP)
-10. 🗣 Commented on [#985](https://github.com/scilus/scilpy/pull/985#issuecomment-2073279393) in [scilus/scilpy](https://github.com/scilus/scilpy)
+1. 🗣 Commented on [#25](https://github.com/njzjz/nodejs-wheel/pull/25#issuecomment-2078310142) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
+2. 🗣 Commented on [#1693](https://github.com/HEXRD/hexrdgui/pull/1693#issuecomment-2078202516) in [HEXRD/hexrdgui](https://github.com/HEXRD/hexrdgui)
+3. 🗣 Commented on [#3](https://github.com/michaelfdickey/my_daily_news/pull/3#issuecomment-2077781293) in [michaelfdickey/my_daily_news](https://github.com/michaelfdickey/my_daily_news)
+4. 🗣 Commented on [#2](https://github.com/michaelfdickey/my_daily_news/pull/2#issuecomment-2077766099) in [michaelfdickey/my_daily_news](https://github.com/michaelfdickey/my_daily_news)
+5. 🗣 Commented on [#2998](https://github.com/astropy/astroquery/pull/2998#issuecomment-2077587980) in [astropy/astroquery](https://github.com/astropy/astroquery)
+6. 🗣 Commented on [#117](https://github.com/eastgenomics/eggd_conductor/pull/117#issuecomment-2077262286) in [eastgenomics/eggd_conductor](https://github.com/eastgenomics/eggd_conductor)
+7. 🗣 Commented on [#2850](https://github.com/metabrainz/listenbrainz-server/pull/2850#issuecomment-2077132820) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+8. 🗣 Commented on [#194](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/194#issuecomment-2076900350) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
+9. 🗣 Commented on [#24](https://github.com/njzjz/nodejs-wheel/pull/24#issuecomment-2076893615) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
+10. 🗣 Commented on [#2997](https://github.com/astropy/astroquery/pull/2997#issuecomment-2076889746) in [astropy/astroquery](https://github.com/astropy/astroquery)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#1550](https://github.com/openSUSE/osc/pull/1550#issuecomment-2080062643) in [openSUSE/osc](https://github.com/openSUSE/osc)
-2. 🗣 Commented on [#22027](https://github.com/spyder-ide/spyder/pull/22027#issuecomment-2079557488) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
-3. 🗣 Commented on [#986](https://github.com/scilus/scilpy/pull/986#issuecomment-2079507038) in [scilus/scilpy](https://github.com/scilus/scilpy)
-4. 🗣 Commented on [#2855](https://github.com/metabrainz/listenbrainz-server/pull/2855#issuecomment-2079430500) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
-5. 🗣 Commented on [#203](https://github.com/eastgenomics/eggd_dias_batch/pull/203#issuecomment-2079401156) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
-6. 🗣 Commented on [#202](https://github.com/eastgenomics/eggd_dias_batch/pull/202#issuecomment-2079400986) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
-7. 🗣 Commented on [#200](https://github.com/eastgenomics/eggd_dias_batch/pull/200#issuecomment-2079400710) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
-8. 🗣 Commented on [#82](https://github.com/eastgenomics/trendyQC/pull/82#issuecomment-2079371531) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
-9. 🗣 Commented on [#495](https://github.com/Spoken-tutorial/spoken-website/pull/495#issuecomment-2079124078) in [Spoken-tutorial/spoken-website](https://github.com/Spoken-tutorial/spoken-website)
-10. 🗣 Commented on [#1497](https://github.com/rpm-software-management/ci-dnf-stack/pull/1497#issuecomment-2079007402) in [rpm-software-management/ci-dnf-stack](https://github.com/rpm-software-management/ci-dnf-stack)
+1. 🗣 Commented on [#882](https://github.com/fury-gl/fury/pull/882#issuecomment-2081184806) in [fury-gl/fury](https://github.com/fury-gl/fury)
+2. 🗣 Commented on [#9235](https://github.com/statsmodels/statsmodels/pull/9235#issuecomment-2080915687) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
+3. 🗣 Commented on [#315](https://github.com/OpenFreeEnergy/gufe/pull/315#issuecomment-2080411439) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
+4. 🗣 Commented on [#26](https://github.com/njzjz/nodejs-wheel/pull/26#issuecomment-2080358896) in [njzjz/nodejs-wheel](https://github.com/njzjz/nodejs-wheel)
+5. 🗣 Commented on [#1550](https://github.com/openSUSE/osc/pull/1550#issuecomment-2080062643) in [openSUSE/osc](https://github.com/openSUSE/osc)
+6. 🗣 Commented on [#22027](https://github.com/spyder-ide/spyder/pull/22027#issuecomment-2079557488) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+7. 🗣 Commented on [#986](https://github.com/scilus/scilpy/pull/986#issuecomment-2079507038) in [scilus/scilpy](https://github.com/scilus/scilpy)
+8. 🗣 Commented on [#2855](https://github.com/metabrainz/listenbrainz-server/pull/2855#issuecomment-2079430500) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+9. 🗣 Commented on [#203](https://github.com/eastgenomics/eggd_dias_batch/pull/203#issuecomment-2079401156) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
+10. 🗣 Commented on [#202](https://github.com/eastgenomics/eggd_dias_batch/pull/202#issuecomment-2079400986) in [eastgenomics/eggd_dias_batch](https://github.com/eastgenomics/eggd_dias_batch)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#1](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast/pull/1#issuecomment-2050705564) in [Mr-Sunglasses/FastApi-Learn-Fast](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast)
-2. 🗣 Commented on [#395](https://github.com/poldracklab/fitlins/pull/395#issuecomment-2050650570) in [poldracklab/fitlins](https://github.com/poldracklab/fitlins)
-3. 🗣 Commented on [#1790](https://github.com/zarr-developers/zarr-python/pull/1790#issuecomment-2050398422) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-4. 🗣 Commented on [#1785](https://github.com/zarr-developers/zarr-python/pull/1785#issuecomment-2050355058) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-5. 🗣 Commented on [#3156](https://github.com/reframe-hpc/reframe/pull/3156#issuecomment-2049917685) in [reframe-hpc/reframe](https://github.com/reframe-hpc/reframe)
-6. 🗣 Commented on [#1124](https://github.com/yeatmanlab/pyAFQ/pull/1124#issuecomment-2048122686) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
-7. 🗣 Commented on [#9191](https://github.com/statsmodels/statsmodels/pull/9191#issuecomment-2048069393) in [statsmodels/statsmodels](https://github.com/statsmodels/statsmodels)
-8. 🗣 Commented on [#1083](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1083#issuecomment-2048039209) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
-9. 🗣 Commented on [#304](https://github.com/OpenFreeEnergy/gufe/pull/304#issuecomment-2047805880) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
-10. 🗣 Commented on [#5](https://github.com/eastgenomics/eggd_add_MANE_annotation/pull/5#issuecomment-2047484088) in [eastgenomics/eggd_add_MANE_annotation](https://github.com/eastgenomics/eggd_add_MANE_annotation)
+1. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
+2. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
+3. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
+4. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
+5. 🗣 Commented on [#2834](https://github.com/metabrainz/listenbrainz-server/pull/2834#issuecomment-2052040367) in [metabrainz/listenbrainz-server](https://github.com/metabrainz/listenbrainz-server)
+6. 🗣 Commented on [#147](https://github.com/DeMarcoLab/autolamella/pull/147#issuecomment-2051218661) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
+7. 🗣 Commented on [#1](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast/pull/1#issuecomment-2050705564) in [Mr-Sunglasses/FastApi-Learn-Fast](https://github.com/Mr-Sunglasses/FastApi-Learn-Fast)
+8. 🗣 Commented on [#395](https://github.com/poldracklab/fitlins/pull/395#issuecomment-2050650570) in [poldracklab/fitlins](https://github.com/poldracklab/fitlins)
+9. 🗣 Commented on [#1790](https://github.com/zarr-developers/zarr-python/pull/1790#issuecomment-2050398422) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
+10. 🗣 Commented on [#1785](https://github.com/zarr-developers/zarr-python/pull/1785#issuecomment-2050355058) in [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#50](https://github.com/codingfriendsfun/pcc/pull/50#issuecomment-2053860585) in [codingfriendsfun/pcc](https://github.com/codingfriendsfun/pcc)
-2. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
-3. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
-4. 🗣 Commented on [#3](https://github.com/cdfxscrq/MyTelegramOrgRoBot/pull/3#issuecomment-2053714065) in [cdfxscrq/MyTelegramOrgRoBot](https://github.com/cdfxscrq/MyTelegramOrgRoBot)
-5. 🗣 Commented on [#631](https://github.com/HEXRD/hexrd/pull/631#issuecomment-2053606917) in [HEXRD/hexrd](https://github.com/HEXRD/hexrd)
-6. 🗣 Commented on [#209](https://github.com/njzjz/deepmd-kit/pull/209#issuecomment-2052922893) in [njzjz/deepmd-kit](https://github.com/njzjz/deepmd-kit)
-7. 🗣 Commented on [#148](https://github.com/DeMarcoLab/autolamella/pull/148#issuecomment-2052654732) in [DeMarcoLab/autolamella](https://github.com/DeMarcoLab/autolamella)
-8. 🗣 Commented on [#4565](https://github.com/MDAnalysis/mdanalysis/pull/4565#issuecomment-2052228126) in [MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
-9. 🗣 Commented on [#1084](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1084#issuecomment-2052094611) in [Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient)
-10. 🗣 Commented on [#497](https://github.com/HEPCloud/decisionengine_modules/pull/497#issuecomment-2052067187) in [HEPCloud/decisionengine_modules](https://github.com/HEPCloud/decisionengine_modules)
+1. 🗣 Commented on [#502](https://github.com/oemof/tespy/pull/502#issuecomment-2057924608) in [oemof/tespy](https://github.com/oemof/tespy)
+2. 🗣 Commented on [#1541](https://github.com/spacetelescope/jwql/pull/1541#issuecomment-2057694211) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
+3. 🗣 Commented on [#114](https://github.com/TIGRLab/datman-dashboard/pull/114#issuecomment-2057473790) in [TIGRLab/datman-dashboard](https://github.com/TIGRLab/datman-dashboard)
+4. 🗣 Commented on [#3158](https://github.com/reframe-hpc/reframe/pull/3158#issuecomment-2057383579) in [reframe-hpc/reframe](https://github.com/reframe-hpc/reframe)
+5. 🗣 Commented on [#1536](https://github.com/openSUSE/osc/pull/1536#issuecomment-2057047173) in [openSUSE/osc](https://github.com/openSUSE/osc)
+6. 🗣 Commented on [#57](https://github.com/eastgenomics/Genetics_Ark/pull/57#issuecomment-2056898482) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+7. 🗣 Commented on [#1383](https://github.com/deepfakes/faceswap/pull/1383#issuecomment-2056546396) in [deepfakes/faceswap](https://github.com/deepfakes/faceswap)
+8. 🗣 Commented on [#50](https://github.com/codingfriendsfun/pcc/pull/50#issuecomment-2053860585) in [codingfriendsfun/pcc](https://github.com/codingfriendsfun/pcc)
+9. 🗣 Commented on [#5](https://github.com/Code-Institute-Solutions/WalkthroughProject01/pull/5#issuecomment-2053766249) in [Code-Institute-Solutions/WalkthroughProject01](https://github.com/Code-Institute-Solutions/WalkthroughProject01)
+10. 🗣 Commented on [#9](https://github.com/sarnold/pyre2/pull/9#issuecomment-2053754241) in [sarnold/pyre2](https://github.com/sarnold/pyre2)
 <!--END_SECTION:activity-->

--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ If you use this project and you like it, [please let me know](https://saythanks.
 
 <!--START_SECTION:activity-->
 
-1. 🗣 Commented on [#22005](https://github.com/spyder-ide/spyder/pull/22005#issuecomment-2062510487) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
-2. 🗣 Commented on [#3194](https://github.com/dipy/dipy/pull/3194#issuecomment-2062351682) in [dipy/dipy](https://github.com/dipy/dipy)
-3. 🗣 Commented on [#1129](https://github.com/yeatmanlab/pyAFQ/pull/1129#issuecomment-2062272758) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
-4. 🗣 Commented on [#307](https://github.com/OpenFreeEnergy/gufe/pull/307#issuecomment-2062103152) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
-5. 🗣 Commented on [#306](https://github.com/OpenFreeEnergy/gufe/pull/306#issuecomment-2062085505) in [OpenFreeEnergy/gufe](https://github.com/OpenFreeEnergy/gufe)
-6. 🗣 Commented on [#42](https://github.com/OpenFreeEnergy/kartograf/pull/42#issuecomment-2061971668) in [OpenFreeEnergy/kartograf](https://github.com/OpenFreeEnergy/kartograf)
-7. 🗣 Commented on [#492](https://github.com/VorTECHsa/python-sdk/pull/492#issuecomment-2061800620) in [VorTECHsa/python-sdk](https://github.com/VorTECHsa/python-sdk)
-8. 🗣 Commented on [#976](https://github.com/scilus/scilpy/pull/976#issuecomment-2061799234) in [scilus/scilpy](https://github.com/scilus/scilpy)
-9. 🗣 Commented on [#192](https://github.com/eastgenomics/eggd_generate_variant_workbook/pull/192#issuecomment-2061652449) in [eastgenomics/eggd_generate_variant_workbook](https://github.com/eastgenomics/eggd_generate_variant_workbook)
-10. 🗣 Commented on [#64](https://github.com/eastgenomics/Genetics_Ark/pull/64#issuecomment-2061495561) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+1. 🗣 Commented on [#212](https://github.com/Fatal1ty/mashumaro/pull/212#issuecomment-2065070135) in [Fatal1ty/mashumaro](https://github.com/Fatal1ty/mashumaro)
+2. 🗣 Commented on [#1544](https://github.com/spacetelescope/jwql/pull/1544#issuecomment-2064994599) in [spacetelescope/jwql](https://github.com/spacetelescope/jwql)
+3. 🗣 Commented on [#304](https://github.com/AdvancedPhotonSource/tike/pull/304#issuecomment-2064390452) in [AdvancedPhotonSource/tike](https://github.com/AdvancedPhotonSource/tike)
+4. 🗣 Commented on [#1684](https://github.com/OGGM/oggm/pull/1684#issuecomment-2064270238) in [OGGM/oggm](https://github.com/OGGM/oggm)
+5. 🗣 Commented on [#72](https://github.com/eastgenomics/trendyQC/pull/72#issuecomment-2063884354) in [eastgenomics/trendyQC](https://github.com/eastgenomics/trendyQC)
+6. 🗣 Commented on [#65](https://github.com/eastgenomics/Genetics_Ark/pull/65#issuecomment-2063359408) in [eastgenomics/Genetics_Ark](https://github.com/eastgenomics/Genetics_Ark)
+7. 🗣 Commented on [#22006](https://github.com/spyder-ide/spyder/pull/22006#issuecomment-2062760737) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+8. 🗣 Commented on [#22005](https://github.com/spyder-ide/spyder/pull/22005#issuecomment-2062510487) in [spyder-ide/spyder](https://github.com/spyder-ide/spyder)
+9. 🗣 Commented on [#3194](https://github.com/dipy/dipy/pull/3194#issuecomment-2062351682) in [dipy/dipy](https://github.com/dipy/dipy)
+10. 🗣 Commented on [#1129](https://github.com/yeatmanlab/pyAFQ/pull/1129#issuecomment-2062272758) in [yeatmanlab/pyAFQ](https://github.com/yeatmanlab/pyAFQ)
 <!--END_SECTION:activity-->

--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -18,14 +18,16 @@ from pep8speaks import utils
 
 def update_users(repository):
     """Star the repository from the bot account"""
+    headers = {'Content-Length': '0'}
     query = f"/user/starred/{repository}"
-    return utils.query_request(query=query, method='PUT')
+    return utils.query_request(query=query, method='PUT', headers=headers)
 
 
 def follow_user(user):
     """Follow the user of the service"""
+    headers = {'Content-Length': '0'}
     query = f"/user/following/{user}"
-    return utils.query_request(query=query, method='PUT')
+    return utils.query_request(query=query, method='PUT', headers=headers)
 
 
 def read_setup_cfg_file(setup_config_file):

--- a/pep8speaks/utils.py
+++ b/pep8speaks/utils.py
@@ -27,7 +27,9 @@ def query_request(query=None, method="GET", **kwargs):
     request_kwargs = {
         "headers": {"Authorization": f"Bearer {GITHUB_TOKEN}"}
     }
-    request_kwargs.update(**kwargs)
+
+    for kw in kwargs:
+        request_kwargs["headers"].update(kwargs[kw])
     return requests.request(method, query, **request_kwargs)
 
 


### PR DESCRIPTION
fix: #227 
fix: #216
 
# Before behaviour

Code: 

```py
def query_request(query=None, method="GET", **kwargs):
    """
    Queries like /repos/:id needs to be appended to the base URL,
    Queries like https://raw.githubusercontent.com need not.

    full list of kwargs see http://docs.python-requests.org/en/master/api/#requests.request
    """

    if query[0] == "/":
        query = BASE_URL + query

    request_kwargs = {
        "headers": {"Authorization": f"Bearer {GITHUB_TOKEN}"}
    }

    
    request_kwargs.update(**kwargs)
    # return requests.request(method, query, **request_kwargs)
    return request_kwargs


def follow_user(user):
    """Follow the user of the service"""
    headers = {"Content-Length": "0"}
    query = f"/user/following/{user}"
    return query_request(query=query, method='PUT', headers=headers)
``` 

Output:

```bash
{'headers': {'Content-Length': '0'}}
```

# After Changes

```bash
{'headers': {'Authorization': 'Bearer TOKEN', 'Content-Length': '0'}}

```