### PR TITLE
Fix pylint warning `unspecified-encoding`

### DIFF
--- a/pep8speaks/helpers.py
+++ b/pep8speaks/helpers.py
@@ -87,7 +87,7 @@ def get_config(repo, base_branch, after_commit_hash):
 
     # Default configuration parameters
     default_config = Path(__file__).absolute().parent.parent.joinpath("data", "default_pep8speaks.yml")
-    with open(default_config, "r") as config_file:
+    with open(default_config, "r", encoding="utf-8") as config_file:
         config = yaml.safe_load(config_file)
 
     linters = ["pycodestyle", "flake8"]


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.