### PR TITLE
Enable tests on Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          # cache: "pip" # caching pip dependencies
+          cache: "pip" # caching pip dependencies
       - name: Install test requirements
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,25 @@
-name: hello-world
-on: push
+name: Build and test
+
+on:
+  pull_request:
+  push:
+    branches: [ "master" ]
+
 jobs:
-  my-job:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: my-step
-        run: echo "Hello World!"
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          # cache: "pip" # caching pip dependencies
+      - name: Install test requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/test.txt
+      - name: Run tests
+        run: |
+          echo "Make sure the review app of this branch is deployed and configured in the test-pep8speaks app"
+          pytest


### PR DESCRIPTION
**Description**

This PR fixes part of #194.

> Move to GHAs to enable CI

This replicates the basic build and test pipeline from `.circleci/config.yml` in a Github Actions workflow.

However, I see the tests themselves are actually failing at the moment (which is also the case on `master`). Assuming this is the right link for CircleCI as well: https://app.circleci.com/pipelines/github/pep8speaks-org/pep8speaks?branch=master

![screenshot_from_2024_10_09_23_08_28](https://github.com/user-attachments/assets/c66c1228-ba3d-4c12-9781-5b4e110eae7d)

To keep the PR scoped to a single thing though, I'd suggest fixing the tests in a separate PR. At least this will make it easy to see when they're fixed. I'm also happy to have a go at fixing the broken tests and put up a second PR if that approach makes sense 😄 

The workflow at a high level:
1. Triggered on every PR and every commit to `master`
2. Runs on the latest Ubuntu runner hosted by GHA
3. Checks out the repo
4. Sets up Python 3.12 (wasn't 100% sure which versions this repo currently supports but I did see 3.8 somewhere, although that's reached EOL by now so I went for 3.12 the latest instead)
5. Upgrades `pip`
6. Installs the test requirements
7. Runs `pytest`
