### PR TITLE
Fix various tests

### DIFF
--- a/pep8speaks/utils.py
+++ b/pep8speaks/utils.py
@@ -68,7 +68,9 @@ def update_dict(base, head):
 
 def match_webhook_secret(request):
     """Match the webhook secret sent from GitHub"""
-    if os.environ.get("OVER_HEROKU", False):
+    heroku_flag = os.environ.get("OVER_HEROKU", False)
+
+    if heroku_flag in (True, "True", "TRUE"):
         if ('X-Hub-Signature' in request.headers and
            request.headers.get('X-Hub-Signature') is not None):
             header_signature = request.headers.get('X-Hub-Signature', None)

--- a/pep8speaks/utils.py
+++ b/pep8speaks/utils.py
@@ -28,8 +28,14 @@ def query_request(query=None, method="GET", **kwargs):
         "headers": {"Authorization": f"Bearer {GITHUB_TOKEN}"}
     }
 
-    for kw in kwargs:
-        request_kwargs["headers"].update(kwargs[kw])
+    for kw, value in kwargs.items():
+        # Merge the headers dicts instead of overwriting it
+        if kw in request_kwargs:
+            request_kwargs[kw].update(value)
+
+        else:
+            request_kwargs[kw] = value
+
     return requests.request(method, query, **request_kwargs)
 
 

--- a/tests/local/pep8speaks/test_utils.py
+++ b/tests/local/pep8speaks/test_utils.py
@@ -49,7 +49,7 @@ class TestUtils:
 
         assert match_webhook_secret(mock_request) is True
 
-        monkeypatch.setenv('OVER_HEROKU', True)
+        monkeypatch.setenv('OVER_HEROKU', 'True')
 
         mock_request.headers = {'Header1': True}
         with pytest.raises(werkzeug.exceptions.Forbidden):

--- a/tests/local/pep8speaks/test_utils.py
+++ b/tests/local/pep8speaks/test_utils.py
@@ -49,7 +49,7 @@ class TestUtils:
 
         assert match_webhook_secret(mock_request) is True
 
-        monkeypatch.setenv('OVER_HEROKU', False)
+        monkeypatch.setenv('OVER_HEROKU', True)
 
         mock_request.headers = {'Header1': True}
         with pytest.raises(werkzeug.exceptions.Forbidden):

--- a/tests/local/pep8speaks/test_utils.py
+++ b/tests/local/pep8speaks/test_utils.py
@@ -9,8 +9,8 @@ from pep8speaks.constants import BASE_URL
 
 class TestUtils:
     @pytest.mark.parametrize('query, method, json, data, headers, params', [
-        ('/someurl', 'POST', {'k1': 'v1'}, '', None, None),
-        ('http://someurl.com', 'GET', None, '', 'h1=v1', 'k1=v1'),
+        ('/someurl', 'POST', {'k1': 'v1'}, '', {'Authorization': 'Bearer '}, None),
+        ('http://someurl.com', 'GET', None, '', {'Authorization': 'Bearer ', 'h1': 'v1'}, 'k1=v1'),
     ])
     def test_request(self, mocker, query, method, json, data, headers, params):
         mock_func = mock.MagicMock(return_value=True)
@@ -20,7 +20,6 @@ class TestUtils:
         assert mock_func.call_count == 1
         assert mock_func.call_args[0][0] == method
         assert mock_func.call_args[1]['headers'] == headers
-        assert mock_func.call_args[1]['auth'] == (os.environ['BOT_USERNAME'], os.environ['GITHUB_TOKEN'])
         assert mock_func.call_args[1]['params'] == params
         assert mock_func.call_args[1]['json'] == json
         if query[0] == "/":
@@ -45,18 +44,20 @@ class TestUtils:
     def test_update_dict(self, base, head, expected):
         assert update_dict(base, head) == expected
 
-    def test_match_webhook_secret(self, monkeypatch, request_ctx):
-        assert match_webhook_secret(request_ctx) is True
+    def test_match_webhook_secret(self, monkeypatch):
+        mock_request = mock.MagicMock()
+
+        assert match_webhook_secret(mock_request) is True
 
         monkeypatch.setenv('OVER_HEROKU', False)
 
-        request_ctx.headers = {'Header1': True}
+        mock_request.headers = {'Header1': True}
         with pytest.raises(werkzeug.exceptions.Forbidden):
-            match_webhook_secret(request_ctx)
+            match_webhook_secret(mock_request)
 
-        request_ctx.headers = {'X-Hub-Signature': None}
+        mock_request.headers = {'X-Hub-Signature': None}
         with pytest.raises(werkzeug.exceptions.Forbidden):
-            match_webhook_secret(request_ctx)
+            match_webhook_secret(mock_request)
 
         key, data = 'testkey', 'testdata'
 
@@ -64,24 +65,24 @@ class TestUtils:
                             data.encode(),
                             digestmod="sha1")
 
-        request_ctx.headers = {
+        mock_request.headers = {
             'X-Hub-Signature': f'{hmac_obj.name}={hmac_obj.hexdigest()}'
         }
         with pytest.raises(werkzeug.exceptions.NotImplemented):
-            match_webhook_secret(request_ctx)
+            match_webhook_secret(mock_request)
 
         hmac_obj = hmac.new(key.encode(),
                             data.encode(),
                             digestmod="sha1")
 
-        request_ctx.headers = {
+        mock_request.headers = {
             'X-Hub-Signature': f'sha1={hmac_obj.hexdigest()}'
         }
-        request_ctx.data = data.encode()
+        mock_request.data = data.encode()
 
         monkeypatch.setenv('GITHUB_PAYLOAD_SECRET', 'wrongkey')
         with pytest.raises(werkzeug.exceptions.Forbidden):
-            match_webhook_secret(request_ctx)
+            match_webhook_secret(mock_request)
 
         monkeypatch.setenv('GITHUB_PAYLOAD_SECRET', key)
-        assert match_webhook_secret(request_ctx) is True
+        assert match_webhook_secret(mock_request) is True

--- a/tests/local/test_server.py
+++ b/tests/local/test_server.py
@@ -24,6 +24,11 @@ class TestApp:
         mock_func = mock.MagicMock(return_value=True)
         mocker.patch('pep8speaks.utils.match_webhook_secret', mock_func)
         mocker.patch('pep8speaks.handlers.' + action, mock_func)
-        client.post(url_for('main'),
-                    headers={"X-GitHub-Event": event})
+        client.post(
+            url_for('main'),
+            headers={"X-GitHub-Event": event},
+            # TODO: This test is not representative of the real JSON payloads sent by Github and should be updated at
+            # some point to have a sample payload fixture for each of the above types.
+            json={"a": "value", "b": 1},
+        )
         assert mock_func.call_count == 2


### PR DESCRIPTION
**Description**

This PR fixes the second half of #194.

During #234, the tests were enabled on GHAs but they weren't passing.

Previous test result from `master`:

```
============================= test session starts ==============================
platform linux -- Python 3.12.7, pytest-7.4.4, pluggy-1.5.0
rootdir: /home/runner/work/pep8speaks/pep8speaks
plugins: mock-3.12.0, flask-1.3.0
collected 28 items

tests/test_workflow.py FFFF                                              [ 14%]
tests/local/test_server.py .FFFFFFFF                                     [ 46%]
tests/local/pep8speaks/test_utils.py FF............E                     [100%]
==================== 14 failed, 13 passed, 1 error in 1.13s ====================
```

Here I've made a few small tweaks to get the test suite passing locally at least (will have to see what happens on GHA):

![screenshot_from_2024_10_16_16_36_46](https://github.com/user-attachments/assets/5cd58d5c-7e94-47e3-91be-d1ec6f9f95da)

I will try to comment on each fix in-line.